### PR TITLE
Fixes #3 - ArgumentOutOfRangeException in ConstantMutator

### DIFF
--- a/trunk/ReadablePassphrase.Core.Test.Unit/ConstantMutatorFixture.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/ConstantMutatorFixture.cs
@@ -1,0 +1,249 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AutoFixture;
+using Moq;
+using MurrayGrant.ReadablePassphrase.Mutators;
+using MurrayGrant.ReadablePassphrase.Random;
+using MurrayGrant.ReadablePassphrase.TestHelpers;
+using NUnit.Framework;
+using static System.String;
+
+namespace MurrayGrant.ReadablePassphrase
+{
+    [TestFixture]
+    public class ConstantMutatorFixture
+    {
+        [TestFixture]
+        public class MutateFixture
+        {
+            [Test]
+            public void Mutate_ForStartOfPhrase_AddsMutation_AtStart([Values("", " ")] string endWhiteSpace)
+            {
+                var fixture = new Fixture();
+                fixture.Customizations.Add(new TestPassphraseBuilder(WordList.Words));
+                //  ARRANGE --------------------------------------------------------
+                var mutChar = ".";
+                //  ReadablePasswordGenerator delimits non-mutated words with spaces
+                var inputSource = fixture.Create<TestPassphrase>();
+                var input = inputSource.Phrase;
+                // An previous mutator may/not have written something at the end with no following whitespace
+                var sb = new StringBuilder(input + endWhiteSpace);
+                //  The constant mutator is placed at the start with its own trailing whitespace
+                var expected = $"{mutChar} {input}{endWhiteSpace}";
+
+                var sut = new ConstantMutator
+                {
+                    ValueToAdd = mutChar,
+                    When = ConstantStyles.StartOfPhrase,
+                    Whitespace = ' '
+                };
+
+                //  ACT ------------------------------------------------------------
+                sut.Mutate(sb, new CryptoRandomSource());
+                var actual = sb.ToString();
+
+                //  ASSERT ---------------------------------------------------------
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+
+            [Test]
+            public void Mutate_ForAnywhere_AddsMutation_AtStart([Values("", " ")] string endWhiteSpace)
+            {
+                var fixture = new Fixture();
+                fixture.Customizations.Add(new TestPassphraseBuilder(WordList.Words));
+                //  ARRANGE --------------------------------------------------------
+                var mutChar = ".";
+                //  ReadablePasswordGenerator delimits non-mutated words with spaces
+                var inputSource = fixture.Create<TestPassphrase>();
+                var input = inputSource.Phrase;
+                // An previous mutator may/not have written something at the end with no following whitespace
+                var sb = new StringBuilder(input + endWhiteSpace);
+                //  The constant mutator is placed at the start with its own trailing whitespace
+                var expected = $"{mutChar} {input}{endWhiteSpace}";
+
+                var rnd = new Mock<IRandomSourceBase>();
+                //  Fix the random gen to always return the end index
+                rnd.Setup(x => x.Next(It.IsAny<int>()))
+                    .Returns<int>(x => 0);
+
+                var sut = new ConstantMutator
+                {
+                    ValueToAdd = mutChar,
+                    When = ConstantStyles.Anywhere,
+                    Whitespace = ' '
+                };
+
+                //  ACT ------------------------------------------------------------
+                sut.Mutate(sb, rnd.Object);
+                var actual = sb.ToString();
+
+                //  ASSERT ---------------------------------------------------------
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+
+            [Test]
+            public void Mutate_ForMiddleOfPhrase_AddsMutation_BetweenWords(
+                [Values("", " ")] string endWhiteSpace, [Values(0, 1, 2)] int randIndex)
+            {
+                var fixture = new Fixture();
+                fixture.Customizations.Add(new TestPassphraseBuilder(WordList.Words, 4));
+                //  ARRANGE --------------------------------------------------------
+                var mutChar = ".";
+                //  ReadablePasswordGenerator delimits non-mutated words with spaces
+                var inputSource = fixture.Create<TestPassphrase>();
+                var input = inputSource.Phrase;
+                // An previous mutator may/not have written something at the end with no following whitespace
+                var sb = new StringBuilder(input + endWhiteSpace);
+                //  we expect one less insertion points than there are words (no inserting at start or end)
+                var expectRandLimit = inputSource.Words.Count - 1;
+                //  The constant mutator is placed between words with its own trailing whitespace
+                var wordsCopy = new List<string>(inputSource.Words);
+                wordsCopy.Insert(randIndex + 1, mutChar);
+                var expected = Join(' ', wordsCopy.ToList()) + endWhiteSpace;
+
+                var rnd = new Mock<IRandomSourceBase>();
+                //  Fix the random gen to always return the target index
+                var actualRandLimit = -1;
+                rnd.Setup(x => x.Next(It.IsAny<int>()))
+                    .Returns<int>(x =>
+                    {
+                        actualRandLimit = x;
+                        return randIndex;
+                    });
+
+                var sut = new ConstantMutator
+                {
+                    ValueToAdd = mutChar,
+                    When = ConstantStyles.MiddleOfPhrase,
+                    Whitespace = ' '
+                };
+
+                //  ACT ------------------------------------------------------------
+                sut.Mutate(sb, rnd.Object);
+                var actual = sb.ToString();
+
+                //  ASSERT ---------------------------------------------------------
+                Assert.Multiple(() =>
+                {
+                    Assert.That(actualRandLimit, Is.EqualTo(expectRandLimit), "Random.Next max param not as expected");
+                    Assert.That(actual, Is.EqualTo(expected));
+                });
+            }
+
+            [Test]
+            public void Mutate_ForAnywhere_AddsMutation_BetweenWords(
+                [Values("", " ")] string endWhiteSpace, [Values(0, 1, 2)] int randIndex)
+            {
+                var fixture = new Fixture();
+                fixture.Customizations.Add(new TestPassphraseBuilder(WordList.Words, 4));
+                //  ARRANGE --------------------------------------------------------
+                var mutChar = ".";
+                //  ReadablePasswordGenerator delimits non-mutated words with spaces
+                var inputSource = fixture.Create<TestPassphrase>();
+                var input = inputSource.Phrase;
+                // An previous mutator may/not have written something at the end with no following whitespace
+                var sb = new StringBuilder(input + endWhiteSpace);
+                //  we expect one less insertion points than there are words plus start and end points
+                var expectRandLimit = inputSource.Words.Count - 1 + 2;
+                //  The constant mutator is placed between words with its own trailing whitespace
+                var wordsCopy = new List<string>(inputSource.Words);
+                wordsCopy.Insert(randIndex + 1, mutChar);
+                var expected = Join(' ', wordsCopy.ToList()) + endWhiteSpace;
+
+                var rnd = new Mock<IRandomSourceBase>();
+                //  Fix the random gen to always return the target index
+                var actualRandLimit = -1;
+                rnd.Setup(x => x.Next(It.IsAny<int>()))
+                    .Returns<int>(x =>
+                    {
+                        actualRandLimit = x;
+                        return randIndex + 2;
+                    });
+
+                var sut = new ConstantMutator
+                {
+                    ValueToAdd = mutChar,
+                    When = ConstantStyles.Anywhere,
+                    Whitespace = ' '
+                };
+
+                //  ACT ------------------------------------------------------------
+                sut.Mutate(sb, rnd.Object);
+                var actual = sb.ToString();
+
+                //  ASSERT ---------------------------------------------------------
+                Assert.Multiple(() =>
+                {
+                    Assert.That(actualRandLimit, Is.EqualTo(expectRandLimit), "Random.Next max param not as expected");
+                    Assert.That(actual, Is.EqualTo(expected));
+                });
+            }
+
+            [Test]
+            public void Mutate_ForEndOfPhrase_AddsMutation_AtEnd([Values("", " ")] string endWhiteSpace)
+            {
+                var fixture = new Fixture();
+                fixture.Customizations.Add(new TestPassphraseBuilder(WordList.Words));
+                //  ARRANGE --------------------------------------------------------
+                var mutChar = ".";
+                //  ReadablePasswordGenerator delimits non-mutated words with spaces
+                var inputSource = fixture.Create<TestPassphrase>();
+                var input = inputSource.Phrase;
+                // An previous mutator may/not have written something at the end with no following whitespace
+                var sb = new StringBuilder(input + endWhiteSpace);
+                //  The constant mutator is placed after the ending whitespace
+                var expected = $"{input}{endWhiteSpace}{mutChar}";
+
+                var sut = new ConstantMutator
+                {
+                    ValueToAdd = mutChar,
+                    When = ConstantStyles.EndOfPhrase,
+                    Whitespace = ' '
+                };
+
+                //  ACT ------------------------------------------------------------
+                sut.Mutate(sb, new CryptoRandomSource());
+                var actual = sb.ToString();
+
+                //  ASSERT ---------------------------------------------------------
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+
+            [Test]
+            public void Mutate_ForAnywhere_AddsMutation_AtEnd([Values("", " ")] string endWhiteSpace)
+            {
+                var fixture = new Fixture();
+                fixture.Customizations.Add(new TestPassphraseBuilder(WordList.Words));
+                //  ARRANGE --------------------------------------------------------
+                var mutChar = ".";
+                //  ReadablePasswordGenerator delimits non-mutated words with spaces
+                var inputSource = fixture.Create<TestPassphrase>();
+                var input = inputSource.Phrase;
+                // An previous mutator may/not have written something at the end with no following whitespace
+                var sb = new StringBuilder(input + endWhiteSpace);
+                //  The constant mutator is placed after the ending whitespace
+                var expected = $"{input}{endWhiteSpace}{mutChar}";
+
+                var rnd = new Mock<IRandomSourceBase>();
+                //  Fix the random gen to always return the end index
+                rnd.Setup(x => x.Next(It.IsAny<int>()))
+                    .Returns<int>(x => 1);
+
+                var sut = new ConstantMutator
+                {
+                    ValueToAdd = mutChar,
+                    When = ConstantStyles.Anywhere,
+                    Whitespace = ' '
+                };
+
+                //  ACT ------------------------------------------------------------
+                sut.Mutate(sb, rnd.Object);
+                var actual = sb.ToString();
+
+                //  ASSERT ---------------------------------------------------------
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+        }
+    }
+}

--- a/trunk/ReadablePassphrase.Core.Test.Unit/Properties/AssemblyInfo.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("82725C88-681F-4953-9040-0959F90D882C")]
+
+[assembly: Parallelizable(ParallelScope.Children)]

--- a/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\RandomiseWordList\scowl wordlist up to 50.txt" Link="scowl wordlist up to 50.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>MurrayGrant.ReadablePassphrase</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReadablePassphrase.Core\ReadablePassphrase.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/ReadablePassphrase.Core.Test.Unit.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphrase.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphrase.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using static System.String;
+
+namespace MurrayGrant.ReadablePassphrase.TestHelpers
+{
+    public class TestPassphrase
+    {
+        public TestPassphrase(IReadOnlyList<string> words)
+        {
+            Words = words;
+            Phrase = Join(' ', words);
+        }
+
+        public IReadOnlyList<string> Words { get; }
+        public string Phrase { get; }
+    }
+}

--- a/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphraseBuilder.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphraseBuilder.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace MurrayGrant.ReadablePassphrase.TestHelpers
+{
+    public class TestPassphraseBuilder : ISpecimenBuilder
+    {
+        private readonly int _WordCount;
+        private readonly IReadOnlyList<string> _Words;
+        private readonly System.Random _rnd = new System.Random();
+
+        public TestPassphraseBuilder(Lazy<IReadOnlyList<string>> words, int wordCount = 3)
+        {
+            _WordCount = wordCount;
+            _Words = words.Value ?? throw new ArgumentNullException(nameof(words));
+            //  It should have at least some entries
+            if (_Words.Count < 10) throw new ArgumentException("words does not have enough entries", nameof(words));
+        }
+
+        object ISpecimenBuilder.Create(object request, ISpecimenContext context)
+        {
+            var pi = request as MemberInfo;
+            if (pi?.Name == nameof(TestPassphrase))
+            {
+                var lim = _Words.Count;
+                var words = Enumerable.Range(0, _WordCount)
+                    .Select(_ => _Words[_rnd.Next(lim)])
+                    .ToList();
+                return new TestPassphrase(words);
+            }
+
+            return new NoSpecimen();
+        }
+    }
+}

--- a/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphraseBuilderFixture.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphraseBuilderFixture.cs
@@ -1,0 +1,23 @@
+﻿using AutoFixture;
+using NUnit.Framework;
+
+namespace MurrayGrant.ReadablePassphrase.TestHelpers
+{
+    [TestFixture]
+    public class TestPassphraseBuilderFixture
+    {
+        [Test]
+        public void DoesCustomiseForTestPassphraseType()
+        {
+            //  ARRANGE --------------------------------------------------------
+            var fixture = new Fixture();
+            fixture.Customizations.Add(new TestPassphraseBuilder(WordList.Words));
+
+            //  ACT ------------------------------------------------------------
+            var output = fixture.Create<TestPassphrase>().Phrase;
+
+            //  ASSERT ---------------------------------------------------------
+            Assert.That(output, Has.Length.GreaterThan(0), "expected some passphrase of some length");
+        }
+    }
+}

--- a/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphraseFixture.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/TestPassphraseFixture.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace MurrayGrant.ReadablePassphrase.TestHelpers
+{
+    [TestFixture]
+    public class TestPassphraseFixture
+    {
+        [Test]
+        public void DoesNotGenerateWithTrailingSpace()
+        {
+            //  ARRANGE --------------------------------------------------------
+            var words = WordList.Pick(3);
+            var sut = new TestPassphrase(words);
+
+            //  ACT ------------------------------------------------------------
+            var output = sut.Phrase;
+
+            //  ASSERT ---------------------------------------------------------
+            Assert.That(output, Is.EqualTo(output.Trim()));
+        }
+
+        [Test]
+        public void GeneratesCorrectNumberOfSpaceDelimitedWords([Values(3, 4)] int wordCount)
+        {
+            //  ARRANGE --------------------------------------------------------
+            var words = WordList.Pick(wordCount);
+            var sut = new TestPassphrase(words);
+
+            //  ACT ------------------------------------------------------------
+            var output = sut.Phrase;
+            var actual = output.Split(new[] { ' ' });
+
+            //  ASSERT ---------------------------------------------------------
+            Assert.That(actual, Has.Length.EqualTo(wordCount));
+        }
+
+        [Test]
+        public void GeneratesPhraseFromJoiningWords([Values(3, 4)] int wordCount)
+        {
+            //  ARRANGE --------------------------------------------------------
+            var words = WordList.Pick(wordCount);
+            var sut = new TestPassphrase(words);
+
+            //  ACT ------------------------------------------------------------
+            var actual = sut.Phrase;
+
+            //  ASSERT ---------------------------------------------------------
+            Assert.That(actual, Is.EqualTo(String.Join(' ', sut.Words)));
+        }
+    }
+}

--- a/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/WordList.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/WordList.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+
+namespace MurrayGrant.ReadablePassphrase.TestHelpers
+{
+    public static class WordList
+    {
+        public static readonly Lazy<IReadOnlyList<string>> Words =
+            new Lazy<IReadOnlyList<string>>(ReadWords, LazyThreadSafetyMode.ExecutionAndPublication);
+
+        const string InputWordList = "scowl wordlist up to 50.txt";
+        private static IReadOnlyList<string> ReadWords()
+        {
+            // Read the word list.
+            var bytesForULong = new byte[8];
+            var random = new RNGCryptoServiceProvider();
+            var words = new List<(string word, ulong sortOrder)>();
+            using (var inStream = File.OpenText(InputWordList))
+            {
+                while (!inStream.EndOfStream)
+                {
+                    // Read the word.
+                    var word = inStream.ReadLine();
+                    // Conditions to ignore the word.
+                    if (word.EndsWith("'s"))
+                        continue;
+                    if (word.Length < 3)
+                        continue;
+                    if (word.Length >= 10)
+                        continue;
+
+                    // Create a random number to sort by.
+                    random.GetBytes(bytesForULong);
+                    var sortOrder = BitConverter.ToUInt64(bytesForULong, 0);
+
+                    // Add to list.
+                    words.Add((word, sortOrder));
+                }
+            }
+
+            // Sort in a random order, based on the assigned ULong.
+            return words.OrderBy(w => w.sortOrder).Select(w => w.word).ToList();
+        }
+
+        public static IReadOnlyList<string> Pick(int n)
+        {
+            var rnd = new System.Random();
+            var lim = Words.Value.Count;
+            return Enumerable.Range(0, n)
+                .Select(_ => Words.Value[rnd.Next(lim)])
+                .ToList();
+        }
+    }
+}

--- a/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/WordList.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/WordList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 
 namespace MurrayGrant.ReadablePassphrase.TestHelpers
@@ -19,7 +20,9 @@ namespace MurrayGrant.ReadablePassphrase.TestHelpers
             var bytesForULong = new byte[8];
             var random = new RNGCryptoServiceProvider();
             var words = new List<(string word, ulong sortOrder)>();
-            using (var inStream = File.OpenText(InputWordList))
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            using (var fs = File.Open(InputWordList, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var inStream = new StreamReader(fs, Encoding.GetEncoding(1252)))
             {
                 while (!inStream.EndOfStream)
                 {

--- a/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/WordListFixture.cs
+++ b/trunk/ReadablePassphrase.Core.Test.Unit/TestHelpers/WordListFixture.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace MurrayGrant.ReadablePassphrase.TestHelpers
+{
+    [TestFixture]
+    public class WordListFixture
+    {
+        [Test]
+        public void WordFileIsReadCorrectly()
+        {
+            //  ARRANGE --------------------------------------------------------
+
+            //  ACT ------------------------------------------------------------
+            var actual = WordList.Words.Value.FirstOrDefault(x => x == "outré");
+
+            //  ASSERT ---------------------------------------------------------
+            Assert.That(actual, Is.EqualTo("outré"));
+        }
+    }
+}

--- a/trunk/ReadablePassphrase.Core/Mutators/ConstantMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/ConstantMutator.cs
@@ -41,7 +41,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
             this.When = ConstantStyles.EndOfPhrase;
         }
 
-        public void Mutate(StringBuilder passphrase, RandomSourceBase random)
+        public void Mutate(StringBuilder passphrase, IRandomSourceBase random)
         {
             _ = passphrase ?? throw new ArgumentNullException(nameof(passphrase));
             _ = random ?? throw new ArgumentNullException(nameof(random));

--- a/trunk/ReadablePassphrase.Core/Mutators/ConstantMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/ConstantMutator.cs
@@ -66,7 +66,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
                 {
                     if (passphrase[i] != this.Whitespace)
                     {
-                        possibleInsertIndexes.Add(i + 2);
+                        possibleInsertIndexes.Add(passphrase.Length);
                         break;
                     }
                 }
@@ -94,7 +94,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
             if (toInsertAt == passphrase.Length)
             {
                 // Actually insert the constant at the end of the phrase (without whitespace).
-                passphrase.Insert(toInsertAt-1, this.ValueToAdd);
+                passphrase.Insert(toInsertAt, this.ValueToAdd);
             }
             else if (toInsertAt >= 0)
             {

--- a/trunk/ReadablePassphrase.Core/Mutators/IMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/IMutator.cs
@@ -26,6 +26,6 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
         /// <summary>
         /// Makes changes to an existing passphrase like capitalising or adding numbers.
         /// </summary>
-        void Mutate(StringBuilder passphrase, RandomSourceBase random);
+        void Mutate(StringBuilder passphrase, IRandomSourceBase random);
     }
 }

--- a/trunk/ReadablePassphrase.Core/Mutators/NullMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/NullMutator.cs
@@ -25,7 +25,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
     /// </summary>
     public sealed class NullMutator : ICombinations, IMutator
     {
-        public void Mutate(StringBuilder passphrase, RandomSourceBase random)
+        public void Mutate(StringBuilder passphrase, IRandomSourceBase random)
         {
             return;
         }

--- a/trunk/ReadablePassphrase.Core/Mutators/NumericMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/NumericMutator.cs
@@ -41,7 +41,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
             this.NumberOfNumbersToAdd = 2;
         }
 
-        public void Mutate(StringBuilder passphrase, RandomSourceBase random)
+        public void Mutate(StringBuilder passphrase, IRandomSourceBase random)
         {
             _ = passphrase ?? throw new ArgumentNullException(nameof(passphrase));
             _ = random ?? throw new ArgumentNullException(nameof(random));

--- a/trunk/ReadablePassphrase.Core/Mutators/UppercaseMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/UppercaseMutator.cs
@@ -38,7 +38,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
         public UppercaseStyles When { get; set; }
         public int NumberOfCharactersToCapitalise { get; set; }
 
-        public void Mutate(StringBuilder passphrase, RandomSourceBase random)
+        public void Mutate(StringBuilder passphrase, IRandomSourceBase random)
         {
             _ = passphrase ?? throw new ArgumentNullException(nameof(passphrase));
             _ = random ?? throw new ArgumentNullException(nameof(random));

--- a/trunk/ReadablePassphrase.Core/Mutators/UppercaseRunMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/UppercaseRunMutator.cs
@@ -39,7 +39,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
         public int NumberOfCharactersInRun { get; set; }
         public int NumberOfRuns { get; set; }
 
-        public void Mutate(StringBuilder passphrase, RandomSourceBase random)
+        public void Mutate(StringBuilder passphrase, IRandomSourceBase random)
         {
             _ = passphrase ?? throw new ArgumentNullException(nameof(passphrase));
             _ = random ?? throw new ArgumentNullException(nameof(random));

--- a/trunk/ReadablePassphrase.Core/Mutators/UppercaseWordMutator.cs
+++ b/trunk/ReadablePassphrase.Core/Mutators/UppercaseWordMutator.cs
@@ -38,7 +38,7 @@ namespace MurrayGrant.ReadablePassphrase.Mutators
         public int NumberOfWordsToCapitalise { get; set; }
         public int MinimumWordLength { get; set; }
 
-        public void Mutate(StringBuilder passphrase, RandomSourceBase random)
+        public void Mutate(StringBuilder passphrase, IRandomSourceBase random)
         {
             _ = passphrase ?? throw new ArgumentNullException(nameof(passphrase));
             _ = random ?? throw new ArgumentNullException(nameof(random));

--- a/trunk/ReadablePassphrase.Core/Random/IRandomSourceBase.cs
+++ b/trunk/ReadablePassphrase.Core/Random/IRandomSourceBase.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2011 Murray Grant
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace MurrayGrant.ReadablePassphrase.Random
+{
+    public interface IRandomSourceBase
+    {
+        bool CoinFlip();
+        byte[] GetRandomBytes(int numberOfBytes);
+        int Next();
+        int Next(int maxExlusive);
+        int Next(int minValue, int maxValue);
+        bool WeightedCoinFlip(int trueWeight, int falseWeight);
+    }
+}

--- a/trunk/ReadablePassphrase.Core/Random/RandomSource.cs
+++ b/trunk/ReadablePassphrase.Core/Random/RandomSource.cs
@@ -26,7 +26,7 @@ namespace MurrayGrant.ReadablePassphrase.Random
     /// <summary>
     /// An abstract source of random bytes (with various easier to use methods)
     /// </summary>
-    public abstract class RandomSourceBase
+    public abstract class RandomSourceBase : IRandomSourceBase
     {
         public abstract byte[] GetRandomBytes(int numberOfBytes);
 

--- a/trunk/ReadablePassphrase.sln
+++ b/trunk/ReadablePassphrase.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReadablePassphrase.DefaultD
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReadablePassphrase", "ReadablePassphrase\ReadablePassphrase.csproj", "{C4A94454-521F-41FC-9C52-8C8DCE621A2E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadablePassphrase.Core.Test.Unit", "ReadablePassphrase.Core.Test.Unit\ReadablePassphrase.Core.Test.Unit.csproj", "{C3433601-C0A1-445C-8CD9-8BEA172AF1D7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -68,6 +70,10 @@ Global
 		{C4A94454-521F-41FC-9C52-8C8DCE621A2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4A94454-521F-41FC-9C52-8C8DCE621A2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4A94454-521F-41FC-9C52-8C8DCE621A2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3433601-C0A1-445C-8CD9-8BEA172AF1D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3433601-C0A1-445C-8CD9-8BEA172AF1D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3433601-C0A1-445C-8CD9-8BEA172AF1D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3433601-C0A1-445C-8CD9-8BEA172AF1D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/trunk/ReadablePassphrase.sln.DotSettings
+++ b/trunk/ReadablePassphrase.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=outr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=outr_00E9/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
This should fix #3 - the `ArgumentOutOfRangeException` in `ConstantMutator`

I've created a unit test project and added a test fixture for the `ConstantMutator` and submitted a fix for the same.

I've had to make some guesses about how `ConstantMutator` is meant to behave. I've assumed

1. The input `StringBuilder` may or may not have a trailing space depending on what mutators have done before this one is invoked, e.g. `"foo"` → `". foo"`
2. If the mutation is to be made at the start, or middle of the phrase then the mutation is inserted with a trailing whitespace separator, e.g. `"foo bar fizz bang"` → `"foo . bar fizz bang"`.
3. If the mutation is to be made at the end of the phrase then the mutation is inserted without a trailing whitespace separator, and before any whitespace that exists, e.g. `"foo 6"` → `"foo 6."` and `"foo "` → `"foo. "`

Assumption (3) in particular seems like it might be wrong, so needs reviewing, but is easy enough to change the tests and code if it needs correcting.

The penultimate commit (`4e8f38b`) will fail the relevant test, and the final commit (`bf246f4`) makes the tests pass by fixing the `Mutate` method. The rest of the commits are just setting up the test infrastructure as there wasn't a unit test project already in place (unless I missed it).