### PR TITLE
use correct framework

### DIFF
--- a/trunk/MergePartsOfSpeech/MergePartsOfSpeech.csproj
+++ b/trunk/MergePartsOfSpeech/MergePartsOfSpeech.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Company>Murray Grant</Company>
     <Product>ReadablePassphrase</Product>
     <Copyright>Copyright © Murray Grant 2011-2024</Copyright>

--- a/trunk/PassphraseGenerator/PassphraseGenerator.csproj
+++ b/trunk/PassphraseGenerator/PassphraseGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;net60;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net60;net452</TargetFrameworks>
     <Company>Murray Grant</Company>
     <Product>ReadablePassphrase</Product>
     <Copyright>Copyright © Murray Grant 2011-2024</Copyright>

--- a/trunk/Test/Test.csproj
+++ b/trunk/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;net60;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net60;net452</TargetFrameworks>
     <Company>Murray Grant</Company>
     <Product>ReadablePassphrase.Test</Product>
     <Copyright>Copyright © Murray Grant 2011-2024</Copyright>

--- a/trunk/build console.cmd
+++ b/trunk/build console.cmd
@@ -21,14 +21,14 @@ copy /y README.txt PassphraseGenerator\bin\Release\net60\publish\README.txt
 zip.exe -9j PassphraseGenerator.net60.zip PassphraseGenerator\bin\Release\net60\publish\*.* 
 
 rem Publish for .NET 8.0
-dotnet publish PassphraseGenerator -c Release -f net80
+dotnet publish PassphraseGenerator -c Release -f net8.0
 
 rem Build ZIP file for .NET 8.0
-del /q PassphraseGenerator.net80.zip
-copy /y ..\LICENSE.txt PassphraseGenerator\bin\Release\net80\publish\LICENSE.txt
-copy /y ..\NOTICE.txt PassphraseGenerator\bin\Release\net80\publish\NOTICE.txt
-copy /y README.txt PassphraseGenerator\bin\Release\net80\publish\README.txt
-zip.exe -9j PassphraseGenerator.net80.zip PassphraseGenerator\bin\Release\net80\publish\*.* 
+del /q PassphraseGenerator.net8.0.zip
+copy /y ..\LICENSE.txt PassphraseGenerator\bin\Release\net8.0\publish\LICENSE.txt
+copy /y ..\NOTICE.txt PassphraseGenerator\bin\Release\net8.0\publish\NOTICE.txt
+copy /y README.txt PassphraseGenerator\bin\Release\net8.0\publish\README.txt
+zip.exe -9j PassphraseGenerator.net8.0.zip PassphraseGenerator\bin\Release\net8.0\publish\*.* 
 
 
 pause


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)